### PR TITLE
Fixes #35: "Using active_url validation rule breaks tests on Links domain"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to `laravel-portugal/api` will be documented in this file
 
 ### Fixed
 
-- N/A
+- Using active_url validation rule breaks tests on Links domain (#35)
 
 ### Security
 

--- a/domains/Links/Controllers/LinksStoreController.php
+++ b/domains/Links/Controllers/LinksStoreController.php
@@ -19,7 +19,7 @@ class LinksStoreController extends Controller
     public function __invoke(Request $request): Response
     {
         $this->validate($request, [
-            'link' => ['required', 'string', 'active_url'],
+            'link' => ['required', 'string', 'url'],
             'title' => ['required', 'string'],
             'description' => ['required', 'string'],
             'author_name' => ['required', 'string'],

--- a/domains/Links/Tests/Feature/LinksStoreTest.php
+++ b/domains/Links/Tests/Feature/LinksStoreTest.php
@@ -18,14 +18,6 @@ class LinksStoreTest extends TestCase
     private Tag $tag;
     private Generator $faker;
 
-    public function invalidLinkProvider(): array
-    {
-        return [
-            ['https://this_is_not_a_valid_url.invalid'],
-            ['this_is_not_a_valid_url'],
-        ];
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -93,15 +85,11 @@ class LinksStoreTest extends TestCase
             ]);
     }
 
-    /** @test
-     * @dataProvider invalidLinkProvider
-     *
-     * @param string $invalidLink
-     */
-    public function it_fails_to_store_resources_with_invalid_link(string $invalidLink): void
+    /** @test */
+    public function it_fails_to_store_resources_with_invalid_link(): void
     {
         $payload = [
-            'link' => $invalidLink,
+            'link' => 'this_is_not_a_valid_url',
             'title' => $this->faker->title,
             'description' => $this->faker->paragraph,
             'author_name' => $this->faker->name,

--- a/domains/Links/Tests/Feature/LinksStoreTest.php
+++ b/domains/Links/Tests/Feature/LinksStoreTest.php
@@ -116,4 +116,30 @@ class LinksStoreTest extends TestCase
                 'link',
             ]);
     }
+
+    /** @test */
+    public function it_stores_resources_with_unregistered_link_domain(): void
+    {
+        Storage::fake('local');
+
+        $payload = [
+            'link' => 'http://unregistered.laravel.pt',
+            'title' => $this->faker->title,
+            'description' => $this->faker->paragraph,
+            'author_name' => $this->faker->name,
+            'author_email' => $this->faker->safeEmail,
+            'tags' => [
+                ['id' => $this->tag->id],
+            ],
+        ];
+
+        $files = [
+            'cover_image' => UploadedFile::fake()->image('cover_image.jpg'),
+        ];
+
+        $response = $this->call('POST', '/links', $payload, [], $files);
+
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertTrue($response->isEmpty());
+    }
 }


### PR DESCRIPTION
This PR changes a rule in the Links domain when storing new Links resources, to not check if the given URL has valid A ou AAAA DNS records.

Closes #35 