### PR TITLE
Adds Frontend Helper command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Homestead.json
 Homestead.yaml
 .env
 .phpunit.result.cache
+database/database.sqlite

--- a/app/Console/Commands/FrontendHelperCommand.php
+++ b/app/Console/Commands/FrontendHelperCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Domains\Links\Database\Factories\LinkFactory;
+use Domains\Tags\Database\Factories\TagFactory;
+use Illuminate\Console\Command;
+
+class FrontendHelperCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = "fh {method=main}";
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Frontend helper. Usage e.g: `php artisan fh links`";
+
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (app()->environment('production')) {
+            $this->info('Not allowed to run in production.');
+            return 0;
+        }
+        $exitCode = $this->{$this->argument('method')}();
+        return $exitCode === null ? 0 : $exitCode;
+    }
+
+    private function getLogo()
+    {
+        return <<<EOT
+         _                               _  ______          _                     _
+        | |                             | | | ___ \        | |                   | |
+        | |     __ _ _ __ __ ___   _____| | | |_/ /__  _ __| |_ _   _  __ _  __ _| |
+        | |    / _` | '__/ _` \ \ / / _ \ | |  __/ _ \| '__| __| | | |/ _` |/ _` | |
+        | |___| (_| | | | (_| |\ V /  __/ | | | | (_) | |  | |_| |_| | (_| | (_| | |
+        \_____/\__,_|_|  \__,_| \_/ \___|_| \_|  \___/|_|   \__|\__,_|\__, |\__,_|_|
+                                                                       __/ |
+                                                                      |___/
+        EOT;
+    }
+
+    private function main()
+    {
+        $this->warn($this->getLogo());
+        $this->info("I'm your artisan frontend helper. Run `php artisan <method>.`");
+        $this->warn('Available:');
+        $this->table(['method'],
+            [
+                ['method' => 'migrateFresh'],
+                ['method' => 'links'],
+                ['method' => 'tags'],
+            ]
+        );
+    }
+
+    private function migrateFresh()
+    {
+        $this->call('migrate:fresh');
+    }
+
+    private function links()
+    {
+        $emailAddresses = ['artisan1@laravel.pt', 'artisan2@laravel.pt'];
+        foreach ($emailAddresses as $emailAddress) {
+            LinkFactory::new()->approved()->withAuthorEmail($emailAddress)->create();
+            $this->info("Successfully inserted {$emailAddress}");
+        }
+    }
+
+    private function tags()
+    {
+        $tags = ['Eloquent', 'Livewire', 'Vue', 'Testing'];
+        foreach ($tags as $tag) {
+            TagFactory::new()->create(['name' => $tag]);
+            $this->info("Successfully inserted {$tag}");
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\FrontendHelperCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Laravel\Lumen\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        FrontendHelperCommand::class,
     ];
 
     /**


### PR DESCRIPTION
While developing the frontend, and implementing e2e tests, we need to provide a simple way to seed some data.

I came up with this solution, having both projects running locally, and the frontend will invoke a shell command on the api project.

The command is a Frontend Helper.

It's very simple for now, but it does the job well.
Usage:
```
php artisan fh
php artisan fh migrateFresh
php artisan fh links # seeds 2 links with known email_authors, artisan1 and artisan2 at laravel.pt
php artisan fh tags # seeds 4 known tags
```

![image](https://user-images.githubusercontent.com/26031459/98780902-74478e80-23ed-11eb-9e85-1f9cb88b12ec.png)

Let me know what you think! 👍 
